### PR TITLE
genomics/lineage: fix to plotting in case of multi-parent lineages

### DIFF
--- a/graphs/genomics.py
+++ b/graphs/genomics.py
@@ -314,7 +314,14 @@ def summarise_lineages(data, threshold=0.15, always_interesting=[]):
                 filtered_lineage.append(lin)
             elif lin in parent_lineages and parent_lineages[lin] != '':
                 summarised_count += 1
-                filtered_lineage.append(parent_lineages[lin])
+                if isinstance(parent_lineages[lin], list):
+                    # This happens if the lineage is a recombination of two parents
+                    # Pick the one with the longest lineage chain to be the parent,
+                    # ie. the most dots in the lineage name. Does not handle ties as is.
+                    main_lineage = max(parent_lineages[lin], key=lambda x: len(x.split(".")))
+                    filtered_lineage.append(main_lineage)
+                else:
+                    filtered_lineage.append(parent_lineages[lin])
             else:
                 lineage_parts = lin.split(".")
                 if len(lineage_parts) == 1:


### PR DESCRIPTION
Some lineages are the result of recombination, and have multiple parents. Previously that case wasn't handled and the plotting errors out. Here pick for the parent of such a lineage the lineage with the most dots in the name (ie. longest chain, most mutations, newest?)

Does not handle ties (when the parents have the same length chain), though such lineages do not exists as of yet.

Example of plot generated with this fix:
![Screenshot_2021-06-05_23-59-04](https://user-images.githubusercontent.com/38863/120907531-2da3d500-c65a-11eb-855a-7a6c91bf8f7c.png)

Fixes #11 